### PR TITLE
♻️ Replace `pybind11` with `nanobind`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       cmake-args: -DBUILD_MQT_QUDITS_BINDINGS=ON
       cpp-linter-extra-args: "-std=c++20"
       files-changed-only: true
-      install-pkgs: "pybind11==3.0.1"
+      install-pkgs: "nanobind==2.10.2"
       setup-python: true
 
   python-tests:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,8 @@ if(BUILD_MQT_QUDITS_BINDINGS)
   endif()
 
   # top-level call to find Python
-  find_package(
-    Python 3.10 REQUIRED
-    COMPONENTS Interpreter Development.Module
-    OPTIONAL_COMPONENTS Development.SABIModule)
+  find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module
+                                               ${SKBUILD_SABI_COMPONENT})
 endif()
 
 # check if this is the master project or used via add_subdirectory

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 # Licensed under the MIT License
 
-add_mqt_python_binding(
+add_mqt_python_binding_nanobind(
   QUDITS
   ${MQT_QUDITS_TARGET_NAME}-bindings
   bindings.cpp

--- a/bindings/bindings.cpp
+++ b/bindings/bindings.cpp
@@ -99,7 +99,6 @@ bool isNoneOrEmpty(const nb::object& obj) {
   }
 
   if (nb::isinstance<nb::sequence>(obj)) {
-    auto seq = nb::cast<nb::sequence>(obj);
     return nb::len(obj) == 0;
   }
 

--- a/bindings/bindings.cpp
+++ b/bindings/bindings.cpp
@@ -23,12 +23,11 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/complex.h> // NOLINT(misc-include-cleaner)
+#include <nanobind/stl/string.h>  // NOLINT(misc-include-cleaner)
+#include <nanobind/stl/vector.h>  // NOLINT(misc-include-cleaner)
 #include <numbers>
-#include <pybind11/cast.h>
-#include <pybind11/complex.h> // NOLINT(misc-include-cleaner)
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl.h> // NOLINT(misc-include-cleaner)
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -37,13 +36,13 @@
 #include <variant>
 #include <vector>
 
-namespace py = pybind11;
-using namespace py::literals;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace {
 
 using Instruction = std::tuple<std::string, bool, std::vector<int>, std::string,
-                               std::vector<int>, py::object,
+                               std::vector<int>, nb::object,
                                std::tuple<std::vector<dd::QuantumRegister>,
                                           std::vector<dd::Control::Type>>>;
 using Circuit = std::vector<Instruction>;
@@ -94,17 +93,15 @@ void printCircuit(const Circuit& circuit) {
 // HELPER FUNCTIONS
 // =======================================================================================================
 
-bool isNoneOrEmpty(const py::object& obj) {
+bool isNoneOrEmpty(const nb::object& obj) {
   if (obj.is_none()) {
     return true;
   }
 
-  if (py::isinstance<py::sequence>(obj)) {
-    auto seq = obj.cast<py::sequence>();
-    return seq.empty();
+  if (nb::isinstance<nb::sequence>(obj)) {
+    auto seq = nb::cast<nb::sequence>(obj);
+    return nb::len(obj) == 0;
   }
-
-  // Add additional checks for other types if needed
 
   return false;
 }
@@ -133,12 +130,12 @@ bool checkDim(const std::vector<int>& dims,
 }
 
 // Function to convert C++ vector of complex numbers to a Python list
-py::list complexVectorToList(const CVec& vec) {
-  py::list pyList;
+nb::list complexVectorToList(const CVec& vec) {
+  nb::list pyList;
   for (const auto& elem : vec) {
     try {
       // Convert std::complex<double> to Python complex object
-      py::object pyComplex = py::cast(elem);
+      nb::object pyComplex = nb::cast(elem);
       // Append Python complex object to the list
       pyList.append(pyComplex);
     } catch (const std::exception& e) {
@@ -153,46 +150,45 @@ py::list complexVectorToList(const CVec& vec) {
 // PARSING FUNCTIONS
 // =======================================================================================================
 
-Circuit_info readCircuit(py::object& circ) {
+Circuit_info readCircuit(nb::object& circ) {
   Circuit result;
 
-  const auto numQudits = circ.attr("_num_qudits").cast<unsigned int>();
-  const auto dimensions = circ.attr("_dimensions").cast<std::vector<size_t>>();
+  const auto numQudits = nb::cast<unsigned int>(circ.attr("_num_qudits"));
+  const auto dimensions =
+      nb::cast<std::vector<size_t>>(circ.attr("_dimensions"));
 
   // Get Python iterable
-  py::iterator it = py::iter(circ.attr("instructions"));
+  nb::iterator it = nb::iter(circ.attr("instructions"));
 
   // Iterate over the Python iterable
-  while (it != py::iterator::sentinel()) {
-    const py::handle objHandle = *it;
-    const auto obj = py::reinterpret_borrow<py::object>(objHandle);
+  while (it != nb::iterator::sentinel()) {
+    const nb::handle objHandle = *it;
+    const auto obj = nb::borrow<nb::object>(objHandle);
 
-    const auto tag = obj.attr("qasm_tag").cast<std::string>();
-
-    const bool dagger = obj.attr("dagger").cast<bool>();
-
-    const std::string gateType =
-        py::cast<std::string>(obj.attr("gate_type").attr("name"));
+    const auto tag = nb::cast<std::string>(obj.attr("qasm_tag"));
+    const auto dagger = nb::cast<bool>(obj.attr("dagger"));
+    const auto gateType =
+        nb::cast<std::string>(obj.attr("gate_type").attr("name"));
 
     // Extracting dimensions
-    const py::object dimsObj = obj.attr("_dimensions");
+    const nb::object dimsObj = obj.attr("_dimensions");
     std::vector<int> dims;
-    if (py::isinstance<py::int_>(dimsObj)) {
-      dims.push_back(py::cast<int>(dimsObj));
-    } else if (py::isinstance<py::list>(dimsObj)) {
-      dims = py::cast<std::vector<int>>(dimsObj);
+    if (nb::isinstance<nb::int_>(dimsObj)) {
+      dims.push_back(nb::cast<int>(dimsObj));
+    } else if (nb::isinstance<nb::list>(dimsObj)) {
+      dims = nb::cast<std::vector<int>>(dimsObj);
     }
 
     // Extracting target_qudits
-    const py::object targetQuditsObj = obj.attr("_target_qudits");
+    const nb::object targetQuditsObj = obj.attr("_target_qudits");
     std::vector<int> targetQudits;
-    if (py::isinstance<py::int_>(targetQuditsObj)) {
-      targetQudits.push_back(py::cast<int>(targetQuditsObj));
-    } else if (py::isinstance<py::list>(targetQuditsObj)) {
-      targetQudits = py::cast<std::vector<int>>(targetQuditsObj);
+    if (nb::isinstance<nb::int_>(targetQuditsObj)) {
+      targetQudits.push_back(nb::cast<int>(targetQuditsObj));
+    } else if (nb::isinstance<nb::list>(targetQuditsObj)) {
+      targetQudits = nb::cast<std::vector<int>>(targetQuditsObj);
     }
 
-    py::object params;
+    nb::object params;
     if (isNoneOrEmpty(obj.attr("_params"))) {
     } else {
       params = obj.attr("_params");
@@ -203,11 +199,11 @@ Circuit_info readCircuit(py::object& circ) {
     if (isNoneOrEmpty(obj.attr("_controls_data"))) {
       // std::cout << "control empty"<< "\n";
     } else {
-      const py::object controlsData = obj.attr("_controls_data");
-      auto indices =
-          controlsData.attr("indices").cast<std::vector<dd::QuantumRegister>>();
-      auto ctrlStates = controlsData.attr("ctrl_states")
-                            .cast<std::vector<dd::Control::Type>>();
+      const nb::object controlsData = obj.attr("_controls_data");
+      auto indices = nb::cast<std::vector<dd::QuantumRegister>>(
+          controlsData.attr("indices"));
+      auto ctrlStates = nb::cast<std::vector<dd::Control::Type>>(
+          controlsData.attr("ctrl_states"));
 
       controlSet = std::make_tuple(indices, ctrlStates);
     }
@@ -222,13 +218,13 @@ Circuit_info readCircuit(py::object& circ) {
   return std::make_tuple(numQudits, dimensions, result);
 }
 
-NoiseModel parseNoiseModel(const py::dict& noiseModel) {
+NoiseModel parseNoiseModel(const nb::dict& noiseModel) {
   NoiseModel newNoiseModel;
 
   for (const auto& gate : noiseModel) {
-    auto gateName = gate.first.cast<std::string>();
+    auto gateName = nb::cast<std::string>(gate.first);
 
-    const auto gateNoise = gate.second.cast<py::dict>();
+    const auto gateNoise = nb::cast<nb::dict>(gate.second);
 
     NoiseType newNoiseType;
 
@@ -236,24 +232,25 @@ NoiseModel parseNoiseModel(const py::dict& noiseModel) {
         noiseSpread; // Declared outside the if blocks
 
     for (const auto& noiseTypesPair : gateNoise) {
-      if (py::isinstance<py::str>(noiseTypesPair.first)) {
-        const auto noiseSpreadString = noiseTypesPair.first.cast<std::string>();
+      if (nb::isinstance<nb::str>(noiseTypesPair.first)) {
+        const auto noiseSpreadString =
+            nb::cast<std::string>(noiseTypesPair.first);
         noiseSpread = noiseSpreadString;
         // Handle string case
-      } else if (py::isinstance<py::tuple>(noiseTypesPair.first)) {
+      } else if (nb::isinstance<nb::tuple>(noiseTypesPair.first)) {
         const auto noiseSpreadTuple =
-            noiseTypesPair.first.cast<std::vector<int>>();
+            nb::cast<std::vector<int>>(noiseTypesPair.first);
         noiseSpread = noiseSpreadTuple;
       }
 
-      if (py::isinstance<py::dict>(noiseTypesPair.second)) {
+      if (nb::isinstance<nb::dict>(noiseTypesPair.second)) {
         throw std::invalid_argument("Physical noise is not supported yet.");
       }
 
-      const auto depo =
-          noiseTypesPair.second.attr("probability_depolarizing").cast<double>();
+      const auto depo = nb::cast<double>(
+          noiseTypesPair.second.attr("probability_depolarizing"));
       const auto deph =
-          noiseTypesPair.second.attr("probability_dephasing").cast<double>();
+          nb::cast<double>(noiseTypesPair.second.attr("probability_dephasing"));
       const std::tuple<double, double> noiseProb = std::make_tuple(depo, deph);
 
       newNoiseType[noiseSpread] = noiseProb;
@@ -336,13 +333,13 @@ Circuit generateCircuit(const Circuit_info& circuitInfo,
                 std::vector<int> dims;
                 dims.push_back(
                     static_cast<int>(dimensions[static_cast<uint64_t>(dit)]));
-                py::list paramsNew;
+                nb::list paramsNew;
 
                 size_t value0 = 0;
                 size_t value1 = 0;
                 // Retrieve field 0 and 1 from params
-                auto pl = params.cast<py::list>();
-                value0 = pl[0].cast<size_t>();
+                auto pl = nb::cast<nb::list>(params);
+                value0 = nb::cast<size_t>(pl[0]);
                 if (tag == "virtrz") {
                   if (dims.size() != 1) {
                     throw std::runtime_error(
@@ -356,7 +353,7 @@ Circuit generateCircuit(const Circuit_info& circuitInfo,
                     value1 = static_cast<size_t>(dims[0] - 1);
                   }
                 } else {
-                  value1 = pl[1].cast<size_t>();
+                  value1 = nb::cast<size_t>(pl[1]);
                 }
 
                 // Create a new list and append value0 and value1
@@ -366,16 +363,16 @@ Circuit generateCircuit(const Circuit_info& circuitInfo,
                 // Append pi and pi/2
                 const auto pi = std::numbers::pi;
                 const auto piOver2 = pi / 2.0;
-                paramsNew.append(py::float_(pi));
-                paramsNew.append(py::float_(piOver2));
+                paramsNew.append(nb::float_(pi));
+                paramsNew.append(nb::float_(piOver2));
                 const Instruction newInst = std::make_tuple(
                     "rxy", false, dims, "SINGLE", std::vector<int>{dit},
-                    py::cast<py::object>(paramsNew),
+                    nb::cast<nb::object>(paramsNew),
                     std::tuple<std::vector<dd::QuantumRegister>,
                                std::vector<dd::Control::Type>>());
                 noisyCircuit.push_back(newInst);
               } else {
-                const py::object paramsNew;
+                const nb::object paramsNew;
                 std::vector<int> dims;
                 dims.push_back(
                     static_cast<int>(dimensions[static_cast<uint64_t>(dit)]));
@@ -393,7 +390,7 @@ Circuit generateCircuit(const Circuit_info& circuitInfo,
           if (zChoice == 1) {
             for (auto dit : qudits) {
               if (tag == "rxy" || tag == "rz" || tag == "virtrz") {
-                py::list paramsNew;
+                nb::list paramsNew;
 
                 std::vector<int> dims;
                 dims.push_back(
@@ -402,8 +399,8 @@ Circuit generateCircuit(const Circuit_info& circuitInfo,
                 size_t value0 = 0;
                 size_t value1 = 0;
                 // Retrieve field 0 and 1 from params
-                auto pl = params.cast<py::list>();
-                value0 = pl[0].cast<size_t>();
+                auto pl = nb::cast<nb::list>(params);
+                value0 = nb::cast<size_t>(pl[0]);
                 if (tag == "virtrz") {
                   if (dims.size() != 1) {
                     throw std::runtime_error(
@@ -418,7 +415,7 @@ Circuit generateCircuit(const Circuit_info& circuitInfo,
                     value1 = static_cast<size_t>(dims[0] - 1);
                   }
                 } else {
-                  value1 = pl[1].cast<size_t>();
+                  value1 = nb::cast<size_t>(pl[1]);
                 }
 
                 // Create a new list and append value0 and value1
@@ -427,15 +424,15 @@ Circuit generateCircuit(const Circuit_info& circuitInfo,
 
                 // Append pi and pi/2
                 const auto pi = std::numbers::pi;
-                paramsNew.append(py::float_(pi));
+                paramsNew.append(nb::float_(pi));
                 const Instruction newInst = std::make_tuple(
                     "rz", false, dims, "SINGLE", std::vector<int>{dit},
-                    py::cast<py::object>(paramsNew),
+                    nb::cast<nb::object>(paramsNew),
                     std::tuple<std::vector<dd::QuantumRegister>,
                                std::vector<dd::Control::Type>>());
                 noisyCircuit.push_back(newInst);
               } else {
-                const py::object paramsNew;
+                const nb::object paramsNew;
                 std::vector<int> dims;
                 dims.push_back(
                     static_cast<int>(dimensions[static_cast<uint64_t>(dit)]));
@@ -496,28 +493,21 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
   }
 
   if (tag == "rxy") {
-    // Handle rxy tag with dimension 2
-    auto pl = params.cast<py::list>();
-    auto leva = pl[0].cast<size_t>();
-    auto levb = pl[1].cast<size_t>();
-    auto theta = pl[2].cast<double>();
-    auto phi = pl[3].cast<double>();
-
+    auto pl = nb::cast<nb::list>(params);
+    auto leva = nb::cast<size_t>(pl[0]);
+    auto levb = nb::cast<size_t>(pl[1]);
+    auto theta = nb::cast<double>(pl[2]);
+    auto phi = nb::cast<double>(pl[3]);
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::RXY(theta, phi);
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
-      // Handle rxy tag with dimension 3
       const dd::TritMatrix matrix = dd::RXY3(theta, phi, leva, levb);
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
-      // Handle rxy tag with dimension 4
       const dd::QuartMatrix matrix = dd::RXY4(theta, phi, leva, levb);
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::RXY5(theta, phi, leva, levb);
       gate =
@@ -530,25 +520,20 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
       gate = dd->makeGateDD<dd::SeptMatrix>(matrix, numberRegs, controlSet, tq);
     }
   } else if (tag == "rz") {
-    auto pl = params.cast<py::list>();
-
-    auto leva = pl[0].cast<size_t>();
-    auto levb = pl[1].cast<size_t>();
-    auto phi = pl[2].cast<double>();
-
+    auto pl = nb::cast<nb::list>(params);
+    auto leva = nb::cast<size_t>(pl[0]);
+    auto levb = nb::cast<size_t>(pl[1]);
+    auto phi = nb::cast<double>(pl[2]);
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::RZ(phi);
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
       const dd::TritMatrix matrix = dd::RZ3(phi, leva, levb);
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
       const dd::QuartMatrix matrix = dd::RZ4(phi, leva, levb);
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::RZ5(phi, leva, levb);
       gate =
@@ -561,23 +546,19 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
       gate = dd->makeGateDD<dd::SeptMatrix>(matrix, numberRegs, controlSet, tq);
     }
   } else if (tag == "rh") {
-    auto pl = params.cast<py::list>();
-    auto leva = pl[0].cast<size_t>();
-    auto levb = pl[1].cast<size_t>();
-
+    auto pl = nb::cast<nb::list>(params);
+    auto leva = nb::cast<size_t>(pl[0]);
+    auto levb = nb::cast<size_t>(pl[1]);
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::RH();
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
       const dd::TritMatrix matrix = dd::RH3(leva, levb);
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
       const dd::QuartMatrix matrix = dd::RH4(leva, levb);
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::RH5(leva, levb);
       gate =
@@ -590,23 +571,19 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
       gate = dd->makeGateDD<dd::SeptMatrix>(matrix, numberRegs, controlSet, tq);
     }
   } else if (tag == "virtrz") {
-    auto pl = params.cast<py::list>();
-    auto leva = pl[0].cast<size_t>();
-    auto phi = pl[1].cast<double>();
-
+    auto pl = nb::cast<nb::list>(params);
+    auto leva = nb::cast<size_t>(pl[0]);
+    auto phi = nb::cast<double>(pl[1]);
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::VirtRZ(phi, leva);
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
       const dd::TritMatrix matrix = dd::VirtRZ3(phi, leva);
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
       const dd::QuartMatrix matrix = dd::VirtRZ4(phi, leva);
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::VirtRZ5(phi, leva);
       gate =
@@ -622,16 +599,13 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::Xmat;
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
       const dd::TritMatrix matrix = dd::X3;
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
       const dd::QuartMatrix matrix = dd::X4;
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::X5;
       gate =
@@ -647,16 +621,13 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::Smat;
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
       const dd::TritMatrix matrix = dd::S3();
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
       const dd::QuartMatrix matrix = dd::S4();
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::S5();
       gate =
@@ -672,16 +643,13 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::Zmat;
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
       const dd::TritMatrix matrix = dd::Z3();
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
       const dd::QuartMatrix matrix = dd::Z4();
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::Z5();
       gate =
@@ -693,21 +661,17 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
       const dd::SeptMatrix matrix = dd::Z7();
       gate = dd->makeGateDD<dd::SeptMatrix>(matrix, numberRegs, controlSet, tq);
     }
-
   } else if (tag == "h") {
     if (checkDim(dims, 2)) {
       const dd::GateMatrix matrix = dd::H();
       gate = dd->makeGateDD<dd::GateMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 3)) {
       const dd::TritMatrix matrix = dd::H3();
       gate = dd->makeGateDD<dd::TritMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 4)) {
       const dd::QuartMatrix matrix = dd::H4();
       gate =
           dd->makeGateDD<dd::QuartMatrix>(matrix, numberRegs, controlSet, tq);
-
     } else if (checkDim(dims, 5)) {
       const dd::QuintMatrix matrix = dd::H5();
       gate =
@@ -720,13 +684,11 @@ dd::MDDPackage::mEdge getGate(const ddpkg& dd, const Instruction& instruction) {
       gate = dd->makeGateDD<dd::SeptMatrix>(matrix, numberRegs, controlSet, tq);
     }
   } else if (tag == "cx") {
-    auto pl = params.cast<py::list>();
-
-    auto leva = pl[0].cast<size_t>();
-    auto levb = pl[1].cast<size_t>();
-    auto ctrlLev = pl[2].cast<dd::Control::Type>();
-    auto phi = pl[3].cast<dd::fp>();
-
+    auto pl = nb::cast<nb::list>(params);
+    auto leva = nb::cast<size_t>(pl[0]);
+    auto levb = nb::cast<size_t>(pl[1]);
+    auto ctrlLev = nb::cast<dd::Control::Type>(pl[2]);
+    auto phi = nb::cast<dd::fp>(pl[3]);
     auto cReg = static_cast<dd::QuantumRegister>(target_qudits.at(0));
     auto target = static_cast<dd::QuantumRegister>(target_qudits.at(1));
     return dd->cex(numberRegs, ctrlLev, phi, leva, levb, cReg, target, dag);
@@ -769,13 +731,13 @@ CVec ddsimulator(dd::QuantumRegisterCount numLines,
   return dd->getVector(psi);
 }
 
-py::list stateVectorSimulation(py::object& circ, py::object& noiseModel) {
+nb::list stateVectorSimulation(nb::object& circ, nb::object& noiseModel) {
   auto parsedCircuitInfo = readCircuit(circ);
   auto [numQudits, dims, original_circuit] = parsedCircuitInfo;
 
   Circuit noisyCircuit = original_circuit;
   const auto noiseModelDict =
-      noiseModel.attr("quantum_errors").cast<py::dict>();
+      nb::cast<nb::dict>(noiseModel.attr("quantum_errors"));
   const NoiseModel newNoiseModel = parseNoiseModel(noiseModelDict);
   noisyCircuit = generateCircuit(parsedCircuitInfo, newNoiseModel);
 
@@ -783,15 +745,12 @@ py::list stateVectorSimulation(py::object& circ, py::object& noiseModel) {
       ddsimulator(static_cast<dd::QuantumRegisterCount>(numQudits),
                   static_cast<std::vector<size_t>>(dims), noisyCircuit);
 
-  py::list result = complexVectorToList(myList);
-
-  return result;
+  return complexVectorToList(myList);
 }
 
 } // namespace
 
-// NOLINTNEXTLINE(misc-include-cleaner)
-PYBIND11_MODULE(MQT_QUDITS_MODULE_NAME, m, py::mod_gil_not_used()) {
+NB_MODULE(MQT_QUDITS_MODULE_NAME, m) {
   auto misim = m.def_submodule("misim");
   misim.def("state_vector_simulation", &stateVectorSimulation, "circuit"_a,
             "noise_model"_a);

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -25,19 +25,11 @@ if(BUILD_MQT_QUDITS_BINDINGS)
     message(STATUS "Found mqt-core package: ${mqt-core_DIR}")
   endif()
 
-  if(NOT SKBUILD)
-    # Manually detect the installed pybind11 package.
-    execute_process(
-      COMMAND "${Python_EXECUTABLE}" -m pybind11 --cmakedir
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      OUTPUT_VARIABLE pybind11_DIR)
-
-    # Add the detected directory to the CMake prefix path.
-    list(APPEND CMAKE_PREFIX_PATH "${pybind11_DIR}")
-  endif()
-
-  # add pybind11 library
-  find_package(pybind11 3.0.1 CONFIG REQUIRED)
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE nanobind_ROOT)
+  find_package(nanobind CONFIG REQUIRED)
 endif()
 
 # cmake-format: off

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ minimum-version = "build-system.requires"
 # Set the wheel install directory
 wheel.install-dir = "mqt/qudits"
 
+# Enable Stable ABI builds for CPython 3.12+
+wheel.py-api = "cp312"
+
 # Set required Ninja version
 ninja.version = ">=1.10"
 
@@ -310,6 +313,11 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 before-build = "uv pip install delvewheel>=1.11.2"
 repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_ARGS = "-T ClangCL" }
+
+[[tool.cibuildwheel.overrides]]
+select = "cp312-*"
+inherit.repair-wheel-command = "append"
+repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
 
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@
 
 [build-system]
 requires = [
-    "pybind11>=3.0.1",
+    "nanobind>=2.10.2",
     "scikit-build-core>=0.11.6",
     "setuptools-scm>=9.2.2",
     "mqt.core~=3.4.0",
@@ -326,7 +326,7 @@ mqt-qudits = { workspace = true }
 
 [dependency-groups]
 build = [
-    "pybind11>=3.0.1",
+    "nanobind>=2.10.2",
     "scikit-build-core>=0.11.6",
     "setuptools-scm>=9.2.2",
     "mqt.core~=3.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -846,6 +846,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/6a/33d1702184d94106d3cdd7bfb788e19723206fce152e303473ca3b946c7b/greenlet-3.3.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6f8496d434d5cb2dce025773ba5597f71f5410ae499d5dd9533e0653258cdb3d", size = 273658, upload-time = "2025-12-04T14:23:37.494Z" },
     { url = "https://files.pythonhosted.org/packages/d6/b7/2b5805bbf1907c26e434f4e448cd8b696a0b71725204fa21a211ff0c04a7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b96dc7eef78fd404e022e165ec55327f935b9b52ff355b067eb4a0267fc1cffb", size = 574810, upload-time = "2025-12-04T14:50:04.154Z" },
     { url = "https://files.pythonhosted.org/packages/94/38/343242ec12eddf3d8458c73f555c084359883d4ddc674240d9e61ec51fd6/greenlet-3.3.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73631cd5cccbcfe63e3f9492aaa664d278fda0ce5c3d43aeda8e77317e38efbd", size = 586248, upload-time = "2025-12-04T14:57:39.35Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/0ae86792fb212e4384041e0ef8e7bc66f59a54912ce407d26a966ed2914d/greenlet-3.3.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b299a0cb979f5d7197442dccc3aee67fce53500cd88951b7e6c35575701c980b", size = 597403, upload-time = "2025-12-04T15:07:10.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/a8/15d0aa26c0036a15d2659175af00954aaaa5d0d66ba538345bd88013b4d7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dee147740789a4632cace364816046e43310b59ff8fb79833ab043aefa72fd5", size = 586910, upload-time = "2025-12-04T14:25:59.705Z" },
     { url = "https://files.pythonhosted.org/packages/e1/9b/68d5e3b7ccaba3907e5532cf8b9bf16f9ef5056a008f195a367db0ff32db/greenlet-3.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:39b28e339fc3c348427560494e28d8a6f3561c8d2bcf7d706e1c624ed8d822b9", size = 1547206, upload-time = "2025-12-04T15:04:21.027Z" },
     { url = "https://files.pythonhosted.org/packages/66/bd/e3086ccedc61e49f91e2cfb5ffad9d8d62e5dc85e512a6200f096875b60c/greenlet-3.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3c374782c2935cc63b2a27ba8708471de4ad1abaa862ffdb1ef45a643ddbb7d", size = 1613359, upload-time = "2025-12-04T14:27:26.548Z" },
@@ -853,6 +854,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -860,6 +862,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -867,6 +870,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
+    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -874,6 +878,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
     { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
     { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
     { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
     { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
     { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
@@ -881,6 +886,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
     { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
@@ -1568,14 +1574,14 @@ dependencies = [
 [package.dev-dependencies]
 build = [
     { name = "mqt-core" },
-    { name = "pybind11" },
+    { name = "nanobind" },
     { name = "scikit-build-core" },
     { name = "setuptools-scm" },
 ]
 dev = [
     { name = "mqt-core" },
+    { name = "nanobind" },
     { name = "nox" },
-    { name = "pybind11" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-sugar" },
@@ -1631,14 +1637,14 @@ requires-dist = [
 [package.metadata.requires-dev]
 build = [
     { name = "mqt-core", specifier = "~=3.4.0" },
-    { name = "pybind11", specifier = ">=3.0.1" },
+    { name = "nanobind", specifier = ">=2.10.2" },
     { name = "scikit-build-core", specifier = ">=0.11.6" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 dev = [
     { name = "mqt-core", specifier = "~=3.4.0" },
+    { name = "nanobind", specifier = ">=2.10.2" },
     { name = "nox", specifier = ">=2025.11.12" },
-    { name = "pybind11", specifier = ">=3.0.1" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
@@ -1707,6 +1713,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
+]
+
+[[package]]
+name = "nanobind"
+version = "2.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/7b/818fe4f6d1fdd516a14386ba86f2cbbac1b7304930da0f029724e9001658/nanobind-2.10.2.tar.gz", hash = "sha256:08509910ce6d1fadeed69cb0880d4d4fcb77739c6af9bd8fb4419391a3ca4c6b", size = 993651, upload-time = "2025-12-10T10:55:32.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/06/cb08965f985a5e1b9cb55ed96337c1f6daaa6b9cbdaeabe6bb3f7a1a11df/nanobind-2.10.2-py3-none-any.whl", hash = "sha256:6976c1b04b90481d2612b346485a3063818c6faa5077fe9d8bbc9b5fbe29c380", size = 246514, upload-time = "2025-12-10T10:55:30.741Z" },
 ]
 
 [[package]]
@@ -2216,15 +2231,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
-]
-
-[[package]]
-name = "pybind11"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/7b/a6d8dcb83c457e24a9df1e4d8fd5fb8034d4bbc62f3c324681e8a9ba57c2/pybind11-3.0.1.tar.gz", hash = "sha256:9c0f40056a016da59bab516efb523089139fcc6f2ba7e4930854c61efb932051", size = 546914, upload-time = "2025-08-22T20:09:27.265Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/8a/37362fc2b949d5f733a8b0f2ff51ba423914cabefe69f1d1b6aab710f5fe/pybind11-3.0.1-py3-none-any.whl", hash = "sha256:aa8f0aa6e0a94d3b64adfc38f560f33f15e589be2175e103c0a33c6bce55ee89", size = 293611, upload-time = "2025-08-22T20:09:25.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR fully replaces `pybind11` with `nanobind`. This change will allow us to ship Stable ABI wheels, saving us PyPI space. 

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
