### PR TITLE
♻️ Auto-generate stub file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,8 @@ jobs:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-linter.yml@d6314c45667c131055a0389afc110e8dedc6da3f # v1.17.11
+    with:
+      check-stubs: true
 
   build-sdist:
     name: 🚀 CD

--- a/bindings/bindings.cpp
+++ b/bindings/bindings.cpp
@@ -751,6 +751,18 @@ nb::list stateVectorSimulation(nb::object& circ, nb::object& noiseModel) {
 
 NB_MODULE(MQT_QUDITS_MODULE_NAME, m) {
   auto misim = m.def_submodule("misim");
-  misim.def("state_vector_simulation", &stateVectorSimulation, "circuit"_a,
-            "noise_model"_a);
+  misim.def(
+      "state_vector_simulation", &stateVectorSimulation, "circuit"_a,
+      "noise_model"_a,
+      nb::sig("def state_vector_simulation(circuit: "
+              "mqt.qudits.quantum_circuit.QuantumCircuit, noise_model: "
+              "mqt.qudits.simulation.noise_tools.NoiseModel) -> list[complex]"),
+      R"pb(Simulate the state vector of a quantum circuit with noise model.
+
+Args:
+    circuit: The quantum circuit to simulate
+    noise_model: The noise model to apply
+
+Returns:
+    list: The state vector of the quantum circuit)pb");
 }

--- a/bindings/bindings.cpp
+++ b/bindings/bindings.cpp
@@ -764,5 +764,5 @@ Args:
     noise_model: The noise model to apply
 
 Returns:
-    list: The state vector of the quantum circuit)pb");
+    The state vector of the quantum circuit)pb");
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import nox
@@ -175,6 +176,52 @@ def docs(session: nox.Session) -> None:
         *shared_args,
         env=env,
     )
+
+
+@nox.session(reuse_venv=True, venv_backend="uv")
+def stubs(session: nox.Session) -> None:
+    """Generate type stubs for Python bindings using nanobind."""
+    env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
+    session.run(
+        "uv",
+        "sync",
+        "--no-dev",
+        "--group",
+        "build",
+        env=env,
+    )
+
+    package_root = Path(__file__).parent / "python" / "mqt" / "qudits"
+
+    session.run(
+        "python",
+        "-m",
+        "nanobind.stubgen",
+        "--recursive",
+        "--include-private",
+        "--output-dir",
+        package_root,
+        "--module",
+        "mqt.qudits._qudits",
+    )
+
+    pyi_files = list(package_root.glob("**/*.pyi"))
+
+    if not pyi_files:
+        session.warn("No .pyi files found")
+        return
+
+    if shutil.which("prek") is None:
+        session.install("prek")
+
+    # Allow both 0 (no issues) and 1 as success codes for fixing up stubs
+    success_codes = [0, 1]
+    session.run("prek", "run", "license-tools", "--files", *pyi_files, external=True, success_codes=success_codes)
+    session.run("prek", "run", "ruff-check", "--files", *pyi_files, external=True, success_codes=success_codes)
+    session.run("prek", "run", "ruff-format", "--files", *pyi_files, external=True, success_codes=success_codes)
+
+    # Run ruff-check again to ensure everything is clean
+    session.run("prek", "run", "ruff-check", "--files", *pyi_files, external=True)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ known-first-party = ["mqt.qudits"]
 "python/mqt/qudits/visualisation/**" = ["T20"]
 "docs/**" = ["T20"]
 "noxfile.py" = ["T20", "TID251"]
-"*.pyi" = ["D418", "PYI021"]  # pydocstyle
+"*.pyi" = ["D418", "E501", "PYI021"]
 "*.ipynb" = [
     "D",    # pydocstyle
     "E402", # Allow imports to appear anywhere in Jupyter notebooks

--- a/python/mqt/qudits/_qudits/__init__.pyi
+++ b/python/mqt/qudits/_qudits/__init__.pyi
@@ -5,3 +5,5 @@
 # SPDX-License-Identifier: MIT
 #
 # Licensed under the MIT License
+
+from . import misim as misim

--- a/python/mqt/qudits/_qudits/misim.pyi
+++ b/python/mqt/qudits/_qudits/misim.pyi
@@ -6,10 +6,12 @@
 #
 # Licensed under the MIT License
 
-from mqt.qudits.quantum_circuit import QuantumCircuit
-from mqt.qudits.simulation.noise_tools import NoiseModel
+import mqt.qudits.quantum_circuit
+import mqt.qudits.simulation.noise_tools
 
-def state_vector_simulation(circuit: QuantumCircuit, noise_model: NoiseModel) -> list[complex]:
+def state_vector_simulation(
+    circuit: mqt.qudits.quantum_circuit.QuantumCircuit, noise_model: mqt.qudits.simulation.noise_tools.NoiseModel
+) -> list[complex]:
     """Simulate the state vector of a quantum circuit with noise model.
 
     Args:
@@ -19,5 +21,3 @@ def state_vector_simulation(circuit: QuantumCircuit, noise_model: NoiseModel) ->
     Returns:
         list: The state vector of the quantum circuit
     """
-
-__all__ = ["state_vector_simulation"]

--- a/python/mqt/qudits/_qudits/misim.pyi
+++ b/python/mqt/qudits/_qudits/misim.pyi
@@ -19,5 +19,5 @@ def state_vector_simulation(
         noise_model: The noise model to apply
 
     Returns:
-        list: The state vector of the quantum circuit
+        The state vector of the quantum circuit
     """


### PR DESCRIPTION
## Description

After we have switched from `pybind11` to `nanobind` in #244, we can now auto-generate the stub file. This PR defines a corresponding `nox` session and copies over all existing docstrings to the bindings code.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
