### PR TITLE
🔧 Maintenance round

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,8 +15,7 @@ jobs:
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
 
   # Builds wheels on all supported platforms using cibuildwheel.
-  # The wheels are uploaded as GitHub artifacts `dev-cibw-*` or `cibw-*`, depending on whether
-  # the workflow is triggered from a PR or a release, respectively.
+  # The wheels are uploaded as GitHub artifacts `dev-cibw-*` or `cibw-*`, depending on whether the workflow is triggered from a PR or a release, respectively.
   build-wheel:
     name: 🐍 Packaging
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,19 +182,19 @@ jobs:
         with:
           allowed-skips: >-
             ${{
-              fromJSON(needs.change-detection.outputs.run-cpp-tests)
-              && '' || 'cpp-tests-ubuntu,cpp-tests-macos,cpp-tests-windows,cpp-coverage,'
+              !fromJSON(needs.change-detection.outputs.run-cpp-tests)
+              && 'cpp-tests-ubuntu,cpp-tests-macos,cpp-tests-windows,cpp-coverage,' || ''
             }}
             ${{
-              fromJSON(needs.change-detection.outputs.run-cpp-linter)
-              && '' || 'cpp-linter,'
+              !fromJSON(needs.change-detection.outputs.run-cpp-linter)
+              && 'cpp-linter,' || ''
             }}
             ${{
-              fromJSON(needs.change-detection.outputs.run-python-tests)
-              && '' || 'python-tests,python-coverage,python-linter,'
+              !fromJSON(needs.change-detection.outputs.run-python-tests)
+              && 'python-tests,python-coverage,python-linter,' || ''
             }}
             ${{
-              fromJSON(needs.change-detection.outputs.run-cd)
-              && '' || 'build-sdist,build-wheel'
+              !fromJSON(needs.change-detection.outputs.run-cd)
+              && 'build-sdist,build-wheel' || ''
             }}
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -19,7 +19,7 @@ jobs:
       - id: create-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: munich-quantum-toolkit/templates@7fe3464fde16330f8d452127a16e29019d7fc81c # v1.3.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,10 @@ test/**/build/
 # ruff
 .ruff_cache/
 
+# Claude
+CLAUDE.md
+.claude/
+
 # OS specific stuff
 .DS_Store
 .DS_Store?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,11 +130,11 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.17
     hooks:
-      - id: ruff-format
-        types_or: [python, pyi, jupyter, markdown]
-        priority: 6
       - id: ruff-check
         require_serial: true
+        priority: 6
+      - id: ruff-format
+        types_or: [python, pyi, jupyter, markdown]
         priority: 7
 
   ## Check Python types with mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,6 +147,6 @@ repos:
         additional_dependencies:
           - pandas-stubs
           - pytest
-          - scipy-stubs
+          - scipy-stubs<1.18.0.0
           - types-networkx
         priority: 8

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ sphinx:
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.14"
   jobs:
     post_checkout:
       # Skip docs build if the commit message contains "skip ci"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Licensed under the MIT License
 
 # set required cmake version
-cmake_minimum_required(VERSION 3.19...3.30)
+cmake_minimum_required(VERSION 3.24...4.2)
 
 # project definition
 project(

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have any questions, feel free to create a [discussion](https://github.com
 
 ## Contributors and Supporters
 
-The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/) and supported by the [Munich Quantum Software Company (MQSC)](https://munichquantum.software).
+The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/) and supported by [MQSC](https://mq.sc).
 Among others, it is part of the [Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss) ecosystem, which is being developed as part of the [Munich Quantum Valley (MQV)](https://www.munich-quantum-valley.de) initiative.
 
 <p align="center">

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -65,8 +65,11 @@ endif()
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
 
 # TODO: Remove when GoogleTest is updated
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
-  # Workaround for a GoogleTest bug with char conversions recognized by Clang 21+. See
-  # https://github.com/google/googletest/issues/4762.
-  target_compile_options(gtest PRIVATE -Wno-character-conversion)
+if(BUILD_MQT_QUDITS_TESTS)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL
+                                                "21")
+    # Workaround for a GoogleTest bug with char conversions recognized by Clang 21+. See
+    # https://github.com/google/googletest/issues/4762.
+    target_compile_options(gtest PRIVATE -Wno-character-conversion)
+  endif()
 endif()

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -63,3 +63,10 @@ endif()
 
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
+
+# TODO: Remove when GoogleTest is updated
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
+  # Workaround for a GoogleTest bug with char conversions recognized by Clang 21+. See
+  # https://github.com/google/googletest/issues/4762.
+  target_compile_options(gtest PRIVATE -Wno-character-conversion)
+endif()

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -54,19 +54,11 @@ if(BUILD_MQT_QUDITS_TESTS)
       ON
       CACHE BOOL "" FORCE)
   set(GTEST_VERSION
-      1.14.0
+      1.17.0
       CACHE STRING "Google Test version")
   set(GTEST_URL https://github.com/google/googletest/archive/refs/tags/v${GTEST_VERSION}.tar.gz)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-    FetchContent_Declare(googletest URL ${GTEST_URL} FIND_PACKAGE_ARGS ${GTEST_VERSION} NAMES GTest)
-    list(APPEND FETCH_PACKAGES googletest)
-  else()
-    find_package(googletest ${GTEST_VERSION} QUIET NAMES GTest)
-    if(NOT googletest_FOUND)
-      FetchContent_Declare(googletest URL ${GTEST_URL})
-      list(APPEND FETCH_PACKAGES googletest)
-    endif()
-  endif()
+  FetchContent_Declare(googletest URL ${GTEST_URL} FIND_PACKAGE_ARGS ${GTEST_VERSION} NAMES GTest)
+  list(APPEND FETCH_PACKAGES googletest)
 endif()
 
 # Make all declared dependencies available.

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -70,6 +70,7 @@ if(BUILD_MQT_QUDITS_TESTS)
                                                 "21")
     # Workaround for a GoogleTest bug with char conversions recognized by Clang 21+. See
     # https://github.com/google/googletest/issues/4762.
+    target_compile_options(gmock PRIVATE -Wno-character-conversion)
     target_compile_options(gtest PRIVATE -Wno-character-conversion)
   endif()
 endif()

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -64,13 +64,12 @@ endif()
 # Make all declared dependencies available.
 FetchContent_MakeAvailable(${FETCH_PACKAGES})
 
-# TODO: Remove when GoogleTest is updated
+# TODO: Remove when https://github.com/google/googletest/issues/4762 is resolved
 if(BUILD_MQT_QUDITS_TESTS)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL
                                                 "21")
-    # Workaround for a GoogleTest bug with char conversions recognized by Clang 21+. See
-    # https://github.com/google/googletest/issues/4762.
     target_compile_options(gmock PRIVATE -Wno-character-conversion)
+    target_compile_options(gmock_main PRIVATE -Wno-character-conversion)
     target_compile_options(gtest PRIVATE -Wno-character-conversion)
   endif()
 endif()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,9 +46,9 @@ except ModuleNotFoundError:
 release = version.split("+")[0]
 
 project = "MQT Qudits"
-author = "Chair for Design Automation, TUM & Munich Quantum Software Company"
+author = "Chair for Design Automation, TUM & Munich Quantum Software Company GmbH"
 language = "en"
-project_copyright = "2023 - 2026 Chair for Design Automation, TUM & 2025 - 2026 Munich Quantum Software Company"
+project_copyright = "2023 - 2026 Chair for Design Automation, TUM & 2025 - 2026 Munich Quantum Software Company GmbH"
 
 master_doc = "index"
 
@@ -56,18 +56,18 @@ templates_path = ["_templates"]
 html_css_files = ["custom.css"]
 
 extensions = [
-    "myst_nb",
     "autoapi.extension",
-    "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.napoleon",
+    "myst_nb",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_inline_tabs",
-    "sphinxext.opengraph",
-    "sphinx.ext.viewcode",
+    "sphinx.ext.autodoc",
     "sphinx.ext.imgconverter",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinxcontrib.bibtex",
+    "sphinxext.opengraph",
 ]
 
 source_suffix = [".rst", ".md"]
@@ -162,6 +162,7 @@ napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 
 # -- Options for HTML output -------------------------------------------------
+
 html_theme = "furo"
 html_static_path = ["_static"]
 html_theme_options = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ api/mqt/qudits/index
 
 ## Contributors and Supporters
 
-The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/) and supported by the [Munich Quantum Software Company (MQSC)](https://munichquantum.software).
+The _[Munich Quantum Toolkit (MQT)](https://mqt.readthedocs.io)_ is developed by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/) and supported by [MQSC](https://mq.sc).
 Among others, it is part of the [Munich Quantum Software Stack (MQSS)](https://www.munich-quantum-valley.de/research/research-areas/mqss) ecosystem, which is being developed as part of the [Munich Quantum Valley (MQV)](https://www.munich-quantum-valley.de) initiative.
 
 <div style="margin-top: 0.5em">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,6 @@ environment = { DEPLOY="ON" }
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 [tool.cibuildwheel.windows]
-before-build = "uv pip install delvewheel>=1.11.2"
 repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_ARGS = "-T ClangCL" }
 


### PR DESCRIPTION
## Description

This PR makes several maintenance updates:

- Fix `required-checks-pass` job
- Use `client-id` instead of `app-id`
- Update to new MQSC branding
- Improve support for `CLAUDE.md`
- Swap priority of `ruff-check` and `ruff-format` hooks
- Configure Read the Docs to use Python 3.14 for colorful docs
- Make use of the fact that version 4.0.0 of `cbuildwheel` installs `delvewheel` by default

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
