### PR TITLE
🐛 Bound adaptive decomposition search

### DIFF
--- a/python/mqt/qudits/compiler/onedit/mapping_aware_transpilation/phy_local_adaptive_decomp.py
+++ b/python/mqt/qudits/compiler/onedit/mapping_aware_transpilation/phy_local_adaptive_decomp.py
@@ -239,7 +239,6 @@ class PhyAdaptiveDecomposition:
         support_size = np.count_nonzero(subdiagonal_support)
         for c in range(dimension - 1):
             for r, r2 in itertools.combinations(range(c, dimension), 2):
-                # ponytail: bound exponential search; raise max_nodes to spend more time before QR fallback.
                 if self.TREE.global_id_counter >= self.max_nodes:
                     break
                 if not subdiagonal_support[r2, c]:

--- a/python/mqt/qudits/compiler/onedit/mapping_aware_transpilation/phy_local_adaptive_decomp.py
+++ b/python/mqt/qudits/compiler/onedit/mapping_aware_transpilation/phy_local_adaptive_decomp.py
@@ -90,7 +90,18 @@ class PhyAdaptiveDecomposition:
         cost_limit: tuple[float, float] | None = (0, 0),
         dimension: int | None = -1,
         z_prop: bool | None = False,
+        max_nodes: int = 1000,
     ) -> None:
+        """Initialize a search capped at max_nodes generated nodes, excluding the root.
+
+        A zero budget only checks whether the input is already diagonal. If no
+        solution is found within the budget, execute returns an empty sequence
+        and infinite costs so the compiler pass can use its QR decomposition.
+        """
+        if max_nodes < 0:
+            msg = "max_nodes must be non-negative."
+            raise ValueError(msg)
+        self.max_nodes = max_nodes
         self.circuit: QuantumCircuit = gate.parent_circuit
         self.U: NDArray[np.complex128] = gate.to_matrix(identities=0)
         self.qudit_index: int = cast("int", gate.target_qudits)
@@ -102,6 +113,7 @@ class PhyAdaptiveDecomposition:
         self.TREE: NAryTree = NAryTree()
 
     def execute(self) -> tuple[list[Gate], tuple[float, float], LevelGraph]:
+        self.TREE.global_id_counter = 0
         self.TREE.add(
             0,
             gates.CustomOne(
@@ -126,8 +138,6 @@ class PhyAdaptiveDecomposition:
             matrices_decomposed_m, final_graph = self.z_extraction(
                 matrices_decomposed, final_graph, self.phase_propagation
             )
-
-        self.TREE.print_tree(self.TREE.root, "TREE: ")
 
         return matrices_decomposed_m, best_cost, final_graph
 
@@ -229,6 +239,9 @@ class PhyAdaptiveDecomposition:
         support_size = np.count_nonzero(subdiagonal_support)
         for c in range(dimension - 1):
             for r, r2 in itertools.combinations(range(c, dimension), 2):
+                # ponytail: bound exponential search; raise max_nodes to spend more time before QR fallback.
+                if self.TREE.global_id_counter >= self.max_nodes:
+                    break
                 if not subdiagonal_support[r2, c]:
                     continue
                 theta = 2 * np.arctan2(abs(u_[r2, c]), abs(u_[r, c]))

--- a/python/mqt/qudits/compiler/onedit/mapping_un_aware_transpilation/log_local_adaptive_decomp.py
+++ b/python/mqt/qudits/compiler/onedit/mapping_un_aware_transpilation/log_local_adaptive_decomp.py
@@ -199,7 +199,6 @@ class LogAdaptiveDecomposition:
         support_size = np.count_nonzero(subdiagonal_support)
         for c in range(dimension - 1):
             for r, r2 in itertools.combinations(range(c, dimension), 2):
-                # ponytail: bound exponential search; raise max_nodes to spend more time before QR fallback.
                 if self.TREE.global_id_counter >= self.max_nodes:
                     break
                 if not subdiagonal_support[r2, c]:

--- a/python/mqt/qudits/compiler/onedit/mapping_un_aware_transpilation/log_local_adaptive_decomp.py
+++ b/python/mqt/qudits/compiler/onedit/mapping_un_aware_transpilation/log_local_adaptive_decomp.py
@@ -83,7 +83,18 @@ class LogAdaptiveDecomposition:
         cost_limit: tuple[float, float] = (0, 0),
         dimension: int = -1,
         z_prop: bool = False,
+        max_nodes: int = 1000,
     ) -> None:
+        """Initialize a search capped at max_nodes generated nodes, excluding the root.
+
+        A zero budget only checks whether the input is already diagonal. If no
+        solution is found within the budget, execute returns an empty sequence
+        and infinite costs so the compiler pass can use its QR decomposition.
+        """
+        if max_nodes < 0:
+            msg = "max_nodes must be non-negative."
+            raise ValueError(msg)
+        self.max_nodes = max_nodes
         self.circuit: QuantumCircuit = gate.parent_circuit
         self.U: NDArray[np.complex128] = gate.to_matrix(identities=0)
         self.qudit_index: int = cast("int", gate.target_qudits)
@@ -95,6 +106,7 @@ class LogAdaptiveDecomposition:
         self.TREE: NAryTree = NAryTree()
 
     def execute(self) -> tuple[list[Gate], tuple[float, float], LevelGraph | None]:
+        self.TREE.global_id_counter = 0
         self.TREE.add(
             0,
             gates.CustomOne(
@@ -116,8 +128,6 @@ class LogAdaptiveDecomposition:
         matrices_decomposed_m: list[Gate] = []
         if matrices_decomposed:
             matrices_decomposed_m, final_graph = self.z_extraction(matrices_decomposed, final_graph)
-
-        self.TREE.print_tree(self.TREE.root, "TREE: ")
 
         return matrices_decomposed_m, best_cost, final_graph
 
@@ -189,6 +199,9 @@ class LogAdaptiveDecomposition:
         support_size = np.count_nonzero(subdiagonal_support)
         for c in range(dimension - 1):
             for r, r2 in itertools.combinations(range(c, dimension), 2):
+                # ponytail: bound exponential search; raise max_nodes to spend more time before QR fallback.
+                if self.TREE.global_id_counter >= self.max_nodes:
+                    break
                 if not subdiagonal_support[r2, c]:
                     continue
                 theta = 2 * np.arctan2(abs(u_[r2, c]), abs(u_[r, c]))

--- a/test/python/compiler/onedit/test_log_local_qr_decomp.py
+++ b/test/python/compiler/onedit/test_log_local_qr_decomp.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from mqt.qudits.compiler.compilation_minitools import UnitaryVerifier
 from mqt.qudits.compiler.onedit.mapping_un_aware_transpilation.log_local_adaptive_decomp import (
@@ -20,8 +21,49 @@ from mqt.qudits.compiler.onedit.mapping_un_aware_transpilation.log_local_adaptiv
 )
 from mqt.qudits.compiler.onedit.mapping_un_aware_transpilation.log_local_qr_decomp import QrDecomp
 from mqt.qudits.core import LevelGraph
+from mqt.qudits.core.dfs_tree import Node
 from mqt.qudits.quantum_circuit import QuantumCircuit
 from mqt.qudits.simulation import MQTQuditProvider
+
+
+@pytest.mark.parametrize("dimension", range(6, 11))
+def test_adaptive_dense_path_graph(dimension: int):
+    rng = np.random.default_rng(427)
+    matrix = rng.normal(size=(dimension, dimension)) + 1j * rng.normal(size=(dimension, dimension))
+    unitary, _ = np.linalg.qr(matrix)
+    circuit = QuantumCircuit(1, [dimension], 0)
+    target = circuit.cu_one(0, unitary)
+    graph = LevelGraph(
+        [(level, level + 1, {}) for level in range(dimension - 1)],
+        list(range(dimension)),
+        rng.permutation(dimension).tolist(),
+        [0],
+        0,
+        circuit,
+    )
+    backend = MQTQuditProvider().get_backend("faketraps2six")
+    backend.energy_level_graphs[0] = graph
+    tree_sizes = []
+    original_execute = LogAdaptiveDecomposition.execute
+    original_add = Node.add
+
+    def execute_and_record(decomposition: LogAdaptiveDecomposition):
+        result = original_execute(decomposition)
+        tree_sizes.append(decomposition.TREE.total_size)
+        return result
+
+    def add_with_limit(node: Node, new_key: int, *args):
+        assert new_key <= 1000, "Adaptive search exceeded its node budget"
+        return original_add(node, new_key, *args)
+
+    with (
+        patch.object(LogAdaptiveDecomposition, "execute", execute_and_record),
+        patch.object(Node, "add", add_with_limit),
+    ):
+        decomposition = LogLocAdaPass(backend).transpile_gate(target)
+
+    assert 1 < tree_sizes[0] <= 1001
+    assert UnitaryVerifier(decomposition, target, [dimension]).verify()
 
 
 class TestLogLocQRPass(TestCase):
@@ -43,12 +85,21 @@ class TestLogLocQRPass(TestCase):
         backend = MQTQuditProvider().get_backend("faketraps2six")
         backend.energy_level_graphs[0] = graph
 
-        def no_adaptive_solution(decomposition: LogAdaptiveDecomposition):
-            return [], (np.inf, np.inf), decomposition.graph
+        searches = []
 
-        with patch.object(LogAdaptiveDecomposition, "execute", no_adaptive_solution):
+        def bounded_search(*args, **kwargs):
+            search = LogAdaptiveDecomposition(*args, **kwargs, max_nodes=1)
+            searches.append(search)
+            return search
+
+        with patch(
+            "mqt.qudits.compiler.onedit.mapping_un_aware_transpilation.log_local_adaptive_decomp.LogAdaptiveDecomposition",
+            side_effect=bounded_search,
+        ):
             decomposition = LogLocAdaPass(backend).transpile_gate(target)
 
+        assert searches[0].TREE.total_size == 2
+        assert not searches[0].TREE.root.finished
         assert decomposition
         assert UnitaryVerifier(decomposition, target, [dimension]).verify()
 
@@ -87,6 +138,37 @@ class TestQrDecomp(TestCase):
 
 
 class TestLogAdaptiveDecomposition(TestCase):
+    @staticmethod
+    def test_node_budget():
+        dimension = 3
+        circuit = QuantumCircuit(1, [dimension], 0)
+        graph = LevelGraph([(0, 1, {}), (1, 2, {})], [0, 1, 2], [0, 1, 2], [0], 0, circuit)
+        target = circuit.r(0, [0, 1, np.pi / 3, np.pi / 5])
+        adaptive = LogAdaptiveDecomposition(target, graph, (np.inf, np.inf), dimension, max_nodes=0)
+        decomposition, best_cost, _ = adaptive.execute()
+
+        assert decomposition == []
+        assert best_cost == (np.inf, np.inf)
+        assert adaptive.TREE.total_size == 1
+
+        adaptive = LogAdaptiveDecomposition(target, graph, (np.inf, np.inf), dimension, max_nodes=1)
+        for _ in range(2):
+            decomposition, best_cost, _ = adaptive.execute()
+            assert np.isfinite(best_cost[1])
+            assert adaptive.TREE.total_size == 2
+            assert UnitaryVerifier(decomposition, target, [dimension]).verify()
+
+        diagonal = circuit.cu_one(0, np.diag(np.exp(1j * np.array([0.2, -0.7, 0.4]))))
+        adaptive = LogAdaptiveDecomposition(diagonal, graph, dimension=dimension, max_nodes=0)
+        decomposition, best_cost, _ = adaptive.execute()
+
+        assert best_cost == (0, 0)
+        assert adaptive.TREE.total_size == 1
+        assert UnitaryVerifier(decomposition, diagonal, [dimension]).verify()
+
+        with pytest.raises(ValueError, match="max_nodes"):
+            LogAdaptiveDecomposition(target, graph, dimension=dimension, max_nodes=-1)
+
     @staticmethod
     def test_execute_path_graph():
         dimension = 4

--- a/test/python/compiler/onedit/test_phy_local_adaptive_decomp.py
+++ b/test/python/compiler/onedit/test_phy_local_adaptive_decomp.py
@@ -13,11 +13,13 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from mqt.qudits.compiler import QuditCompiler
 from mqt.qudits.compiler.compilation_minitools import UnitaryVerifier
 from mqt.qudits.compiler.onedit.mapping_aware_transpilation import PhyAdaptiveDecomposition, PhyQrDecomp
 from mqt.qudits.core import LevelGraph
+from mqt.qudits.core.dfs_tree import Node
 from mqt.qudits.quantum_circuit import QuantumCircuit
 from mqt.qudits.simulation import MQTQuditProvider
 
@@ -43,6 +45,47 @@ def _assert_compiled_unitary(
     initial_permutation = np.eye(len(initial_mapping))[:, initial_mapping]
     final_permutation = np.eye(len(initial_mapping))[:, compiled.mappings[0]]
     assert np.allclose(initial_permutation.T @ actual @ final_permutation, target)
+
+
+@pytest.mark.parametrize("dimension", range(6, 11))
+def test_compile_dense_path_graph(dimension: int):
+    rng = np.random.default_rng(427)
+    matrix = rng.normal(size=(dimension, dimension)) + 1j * rng.normal(size=(dimension, dimension))
+    unitary, _ = np.linalg.qr(matrix)
+    initial_mapping = rng.permutation(dimension).tolist()
+    circuit = QuantumCircuit(1, [dimension], 0)
+    circuit.cu_one(0, unitary)
+    graph = LevelGraph(
+        [(level, level + 1, {}) for level in range(dimension - 1)],
+        list(range(dimension)),
+        initial_mapping,
+        [0],
+        0,
+        circuit,
+    )
+    backend = MQTQuditProvider().get_backend("faketraps2six")
+    backend.energy_level_graphs[0] = graph
+    tree_sizes = []
+    original_execute = PhyAdaptiveDecomposition.execute
+    original_add = Node.add
+
+    def execute_and_record(decomposition: PhyAdaptiveDecomposition):
+        result = original_execute(decomposition)
+        tree_sizes.append(decomposition.TREE.total_size)
+        return result
+
+    def add_with_limit(node: Node, new_key: int, *args):
+        assert new_key <= 1000, "Adaptive search exceeded its node budget"
+        return original_add(node, new_key, *args)
+
+    with (
+        patch.object(PhyAdaptiveDecomposition, "execute", execute_and_record),
+        patch.object(Node, "add", add_with_limit),
+    ):
+        compiled = QuditCompiler.compile_O2(backend, circuit)
+
+    assert 1 < tree_sizes[0] <= 1001
+    _assert_compiled_unitary(compiled, unitary, initial_mapping)
 
 
 class TestPhyLocAdaPass(TestCase):
@@ -96,17 +139,59 @@ class TestPhyLocAdaPass(TestCase):
         backend = MQTQuditProvider().get_backend("faketraps2six")
         backend.energy_level_graphs[0] = graph
 
-        def no_adaptive_solution(decomposition: PhyAdaptiveDecomposition):
-            return [], (np.inf, np.inf), decomposition.graph
+        searches = []
 
-        with patch.object(PhyAdaptiveDecomposition, "execute", no_adaptive_solution):
+        def bounded_search(*args, **kwargs):
+            search = PhyAdaptiveDecomposition(*args, **kwargs, max_nodes=1)
+            searches.append(search)
+            return search
+
+        with patch(
+            "mqt.qudits.compiler.onedit.mapping_aware_transpilation.phy_local_adaptive_decomp.PhyAdaptiveDecomposition",
+            side_effect=bounded_search,
+        ):
             compiled = QuditCompiler.compile_O2(backend, circuit)
 
+        assert searches[0].TREE.total_size == 2
+        assert not searches[0].TREE.root.finished
         assert compiled.instructions
         _assert_compiled_unitary(compiled, _qft_matrix(dimension), initial_mapping)
 
 
 class TestPhyAdaptiveDecomposition(TestCase):
+    @staticmethod
+    def test_node_budget():
+        dimension = 3
+        nodes = list(range(dimension))
+        mapping = [1, 0, 2]
+        circuit = QuantumCircuit(1, [dimension], 0)
+        graph = LevelGraph([(0, 1, {}), (1, 2, {})], nodes, mapping, [0], 0, circuit)
+        target = circuit.r(0, [0, 1, np.pi / 3, np.pi / 5])
+        adaptive = PhyAdaptiveDecomposition(target, graph, (np.inf, np.inf), dimension, max_nodes=0)
+        decomposition, best_cost, _ = adaptive.execute()
+
+        assert decomposition == []
+        assert best_cost == (np.inf, np.inf)
+        assert adaptive.TREE.total_size == 1
+
+        adaptive = PhyAdaptiveDecomposition(target, graph, (np.inf, np.inf), dimension, max_nodes=1)
+        for _ in range(2):
+            decomposition, best_cost, final_graph = adaptive.execute()
+            assert np.isfinite(best_cost[1])
+            assert adaptive.TREE.total_size == 2
+            assert UnitaryVerifier(decomposition, target, [dimension], nodes, mapping, final_graph.log_phy_map).verify()
+
+        diagonal = circuit.cu_one(0, np.diag(np.exp(1j * np.array([0.2, -0.7, 0.4]))))
+        adaptive = PhyAdaptiveDecomposition(diagonal, graph, dimension=dimension, max_nodes=0)
+        decomposition, best_cost, final_graph = adaptive.execute()
+
+        assert best_cost == (0, 0)
+        assert adaptive.TREE.total_size == 1
+        assert UnitaryVerifier(decomposition, diagonal, [dimension], nodes, mapping, final_graph.log_phy_map).verify()
+
+        with pytest.raises(ValueError, match="max_nodes"):
+            PhyAdaptiveDecomposition(target, graph, dimension=dimension, max_nodes=-1)
+
     @staticmethod
     def test_execute_preserves_later_column_branch():
         dimension = 4


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Cap physical and logical adaptive searches at 1,000 generated nodes by default, with a configurable `max_nodes` budget. If no complete solution is found within the budget, the compiler uses its QR decomposition. This prevents dense path-graph inputs from spending excessive time exploring branches, at the cost of ending optimization early.

Add regressions for dimensions 6–10, exhausted budgets, and solutions found exactly at the limit.

Fixes #427

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qudits/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
