### PR TITLE
🐛 Fix phase propagation across adaptive gate decompositions

### DIFF
--- a/python/mqt/qudits/compiler/onedit/mapping_aware_transpilation/phy_local_adaptive_decomp.py
+++ b/python/mqt/qudits/compiler/onedit/mapping_aware_transpilation/phy_local_adaptive_decomp.py
@@ -48,6 +48,18 @@ class PhyLocAdaPass(CompilerPass):
 
     def transpile_gate(self, gate: Gate) -> list[Gate]:
         energy_graph_i = self.backend.energy_level_graphs[cast("int", gate.target_qudits)]
+        dimension = cast("int", gate.dimensions)
+        phases = np.array([energy_graph_i.nodes[level].get("phase_storage", 0) for level in range(dimension)])
+        # Fold pending phases into the adjoint so the decomposition follows execution order.
+        gate = gates.CustomOne(
+            gate.parent_circuit,
+            "CUo",
+            cast("int", gate.target_qudits),
+            np.exp(1j * phases)[:, None] * gate.to_matrix(identities=0).conj().T,
+            dimension,
+        )
+        for node in energy_graph_i.nodes:
+            energy_graph_i.nodes[node]["phase_storage"] = 0
 
         qr = PhyQrDecomp(gate, energy_graph_i)
 
@@ -64,7 +76,7 @@ class PhyLocAdaPass(CompilerPass):
             for node in new_energy_level_graph.nodes:
                 new_energy_level_graph.nodes[node]["phase_storage"] = 0
         self.backend.energy_level_graphs[cast("int", gate.target_qudits)] = new_energy_level_graph
-        return [op.dag() for op in reversed(matrices_decomposed)]
+        return matrices_decomposed
 
     def transpile(self, circuit: QuantumCircuit) -> QuantumCircuit:
         self.circuit: QuantumCircuit = circuit

--- a/test/python/compiler/onedit/test_phy_local_adaptive_decomp.py
+++ b/test/python/compiler/onedit/test_phy_local_adaptive_decomp.py
@@ -44,7 +44,61 @@ def _assert_compiled_unitary(
         actual = gate.to_matrix(identities=0) @ actual
     initial_permutation = np.eye(len(initial_mapping))[:, initial_mapping]
     final_permutation = np.eye(len(initial_mapping))[:, compiled.mappings[0]]
-    assert np.allclose(initial_permutation.T @ actual @ final_permutation, target)
+    assert np.allclose(final_permutation.T @ actual @ initial_permutation, target)
+
+
+@pytest.mark.parametrize("dimension", [2, 3])
+@pytest.mark.parametrize("last_max_nodes", [0, 1000])
+def test_compile_propagated_phases(dimension: int, last_max_nodes: int):
+    circuit = QuantumCircuit(1, [dimension], 0)
+    if dimension == 2:
+        circuit.cu_one(0, np.diag([1, np.exp(1j * np.pi / 3)]))
+        circuit.h(0)
+        initial_mapping = [0, 1]
+        edges = [(0, 1, {})]
+    else:
+        rng = np.random.default_rng(42)
+        for _ in range(3):
+            matrix = rng.normal(size=(dimension, dimension)) + 1j * rng.normal(size=(dimension, dimension))
+            unitary, _ = np.linalg.qr(matrix)
+            circuit.cu_one(0, unitary)
+        circuit.instructions[-1].dag()
+        initial_mapping = rng.permutation(dimension).tolist()
+        edges = [(0, 1, {}), (1, 2, {})]
+    target = np.eye(dimension, dtype=np.complex128)
+    for gate in circuit.instructions:
+        target = gate.to_matrix(identities=0) @ target
+    original_daggers = [gate.dagger for gate in circuit.instructions]
+    graph = LevelGraph(
+        edges,
+        list(range(dimension)),
+        initial_mapping,
+        [0],
+        0,
+        circuit,
+    )
+    backend = MQTQuditProvider().get_backend("faketraps2six")
+    backend.energy_level_graphs[0] = graph
+    searches = []
+
+    def bounded_search(*args, **kwargs):
+        max_nodes = last_max_nodes if len(searches) == len(circuit.instructions) - 1 else 1000
+        search = PhyAdaptiveDecomposition(*args, **kwargs, max_nodes=max_nodes)
+        searches.append(search)
+        return search
+
+    with patch(
+        "mqt.qudits.compiler.onedit.mapping_aware_transpilation.phy_local_adaptive_decomp.PhyAdaptiveDecomposition",
+        side_effect=bounded_search,
+    ):
+        compiled = QuditCompiler.compile_O2(backend, circuit)
+
+    assert all(search.TREE.root.finished and search.phase_propagation for search in searches[:-1])
+    assert searches[-1].TREE.root.finished == bool(last_max_nodes)
+    assert [gate.dagger for gate in circuit.instructions] == original_daggers
+    final_graph = backend.energy_level_graphs[0]
+    assert all(final_graph.nodes[node]["phase_storage"] == 0 for node in final_graph)
+    _assert_compiled_unitary(compiled, target, initial_mapping)
 
 
 @pytest.mark.parametrize("dimension", range(6, 11))


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Compile the adjoint and emit its decomposition in execution order so virtual phases and level mappings compose correctly across consecutive gates. Fold stored phases into the next gate before routing and consume them once for either adaptive search or QR fallback.

Previously, a phase gate followed by a Hadamard gate produced the wrong unitary. Add regressions for consecutive gates, routing with changed mappings, and already-adjoint input gates.

This PR is stacked on #445.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qudits/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
